### PR TITLE
Fixes #834

### DIFF
--- a/Adyen/Model/Checkout/BrowserInfo.cs
+++ b/Adyen/Model/Checkout/BrowserInfo.cs
@@ -81,7 +81,7 @@ namespace Adyen.Model.Checkout
         /// Boolean value indicating if the shopper&#39;s browser is able to execute Java.
         /// </summary>
         /// <value>Boolean value indicating if the shopper&#39;s browser is able to execute Java.</value>
-        [DataMember(Name = "javaEnabled", IsRequired = false, EmitDefaultValue = false)]
+        [DataMember(Name = "javaEnabled", IsRequired = true)]
         public bool JavaEnabled { get; set; }
 
         /// <summary>


### PR DESCRIPTION
**Description**
Fixes the serializer ignoring the property when its set to false, even when intentionally.

Additionally, the property is, according to https://docs.adyen.com/api-explorer/Checkout/70/post/payments#request-browserInfo-javaEnabled, required.

**Fixed issue**:  #834
